### PR TITLE
update database migration strategy to be destructive

### DIFF
--- a/app/src/main/java/com/shearer/jetmoviedb/features/movie/MovieModule.kt
+++ b/app/src/main/java/com/shearer/jetmoviedb/features/movie/MovieModule.kt
@@ -16,7 +16,10 @@ import org.koin.dsl.module.module
 
 
 val movieModule = module {
-    single { Room.databaseBuilder(get(), MovieDb::class.java, "movie-db").build().movies() }
+    single { Room.databaseBuilder(get(), MovieDb::class.java, "movie-db")
+            .fallbackToDestructiveMigration()
+            .build()
+            .movies() }
     factory { MovieRepositoryDefault(get()) as MovieRepository }
     factory { MovieDbRepositoryDefault(get()) as MovieDbRepository }
     factory { MovieInteractorDefault(get(), get()) as MovieInteractor }

--- a/app/src/main/java/com/shearer/jetmoviedb/features/movie/common/db/MovieDb.kt
+++ b/app/src/main/java/com/shearer/jetmoviedb/features/movie/common/db/MovieDb.kt
@@ -4,7 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.shearer.jetmoviedb.features.movie.common.domain.Movie
 
-@Database(entities = [Movie::class], version = 1, exportSchema = false)
+@Database(entities = [Movie::class], version = 2, exportSchema = false)
 abstract class MovieDb : RoomDatabase() {
     abstract fun movies(): MovieDao
 }


### PR DESCRIPTION
fix for
```
2018-09-05 12:24:52.262 6576-6642/com.shearer.jetmoviedb E/AndroidRuntime: FATAL EXCEPTION: arch_disk_io_0
    Process: com.shearer.jetmoviedb, PID: 6576
    java.lang.IllegalStateException: attempt to re-open an already-closed object: SQLiteDatabase: /data/user/0/com.shearer.jetmoviedb/databases/movie-db
```